### PR TITLE
Add missing emperor plot to the analysis

### DIFF
--- a/ipynb/animation/README.md
+++ b/ipynb/animation/README.md
@@ -1,0 +1,3 @@
+# Playing the animation
+
+See the instructions in the `Animations (processing).ipynb` notebook.


### PR DESCRIPTION
I had already forgotten about this but there are instructions on how to play the animation inside the notebook, I decided to make a note about that in the README.md file.